### PR TITLE
Added support for modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 services:
   - redis-server
   - memcached
-  
+
 before_install:
   - go get github.com/mattn/goveralls
 
@@ -14,12 +14,8 @@ before_script:
   - go vet ./...
 
 go:
-  - 1.7
-  - 1.7.x
-  - 1.8
-  - 1.8.x
-  - 1.9
   - "1.10"
+  - "1.11.x"
   - tip
 
 script:

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,6 @@
+module github.com/adelowo/onecache
+
+require (
+	github.com/bradfitz/gomemcache v0.0.0-20180710155616-bc664df96737
+	github.com/go-redis/redis v6.14.0+incompatible
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/bradfitz/gomemcache v0.0.0-20180710155616-bc664df96737 h1:rRISKWyXfVxvoa702s91Zl5oREZTrR3yv+tXrrX7G/g=
+github.com/bradfitz/gomemcache v0.0.0-20180710155616-bc664df96737/go.mod h1:PmM6Mmwb0LSuEubjR8N7PtNe1KxZLtOUHtbeikc5h60=
+github.com/go-redis/redis v6.14.0+incompatible h1:AMPZkM7PbsJbilelrJUAyC4xQbGROTOLSuDd7fnMXCI=
+github.com/go-redis/redis v6.14.0+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=


### PR DESCRIPTION
This adds support for the ___experimental___ modules system in go1.11

This also runs CI on `tip`, `go 1.11` and `go1.10`